### PR TITLE
ci: add tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,53 @@
+on: pull_request
+jobs:
+  unit:
+    name: npm test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+      - run: npm ci
+      - run: npm test
+
+  integ:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-18.04
+          - ubuntu-20.04
+          - windows-2016
+          - windows-2019
+          - macos-10.15
+    name: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+
+      # Test setup specific version
+      - uses: ./
+        with:
+          version: "1.18.2"
+      - run: sam --version | grep -F 1.18.2
+
+      # Test setup latest version
+      - uses: ./
+      - run: sam --version | grep -Fv 1.18.2
+
+      # Test sam init
+      - run: sam init --name sam-app --runtime nodejs14.x --dependency-manager npm --app-template hello-world
+
+      # Test sam build
+      - uses: actions/setup-node@v1
+        with:
+          node-version: "14"
+      - run: sam build
+        working-directory: ./sam-app
+
+      # Test sam build --use-container
+      # Doesn't work as-is on macOS or Windows due to licensing:
+      # - https://github.com/actions/virtual-environments/issues/17
+      # - https://github.com/actions/virtual-environments/issues/1143
+      - if: startsWith(matrix.os, 'ubuntu')
+        run: sam build --use-container
+        working-directory: ./sam-app


### PR DESCRIPTION
Adds test workflow that runs at every PR.

Notes:
- No external input.
- Running workflows from fork PRs is disabled.
- Using branch in this repo so that CI tests can run in the PR.