### PR TITLE
feat: upgrade installation tools

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -75,12 +75,29 @@ async function installSamCli(python, version) {
   const binDir = isWindows() ? "Scripts" : "bin";
   const binPath = path.join(venvPath, binDir);
 
-  const pipPath = path.join(binPath, "pip");
+  // Virtual environment Python
+  const pythonPath = path.join(binPath, "python");
 
-  // Required to install from source and binary distributions
-  await exec.exec(pipPath, ["install", "setuptools", "wheel"]);
+  // Ensure installation tooling is up-to-date across platforms
+  // setuptools and wheel needed for source and binary distributions
+  await exec.exec(pythonPath, ["-m", "pip", "install", "--upgrade", "pip"]);
+  await exec.exec(pythonPath, [
+    "-m",
+    "pip",
+    "install",
+    "--upgrade",
+    "setuptools",
+    "wheel",
+  ]);
+
   // Install latest compatible version
-  await exec.exec(pipPath, ["install", "--upgrade", `aws-sam-cli==${version}`]);
+  await exec.exec(pythonPath, [
+    "-m",
+    "pip",
+    "install",
+    "--upgrade",
+    `aws-sam-cli==${version}`,
+  ]);
 
   return binPath;
 }

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -50,12 +50,29 @@ async function installSamCli(python, version) {
   const binDir = isWindows() ? "Scripts" : "bin";
   const binPath = path.join(venvPath, binDir);
 
-  const pipPath = path.join(binPath, "pip");
+  // Virtual environment Python
+  const pythonPath = path.join(binPath, "python");
 
-  // Required to install from source and binary distributions
-  await exec.exec(pipPath, ["install", "setuptools", "wheel"]);
+  // Ensure installation tooling is up-to-date across platforms
+  // setuptools and wheel needed for source and binary distributions
+  await exec.exec(pythonPath, ["-m", "pip", "install", "--upgrade", "pip"]);
+  await exec.exec(pythonPath, [
+    "-m",
+    "pip",
+    "install",
+    "--upgrade",
+    "setuptools",
+    "wheel",
+  ]);
+
   // Install latest compatible version
-  await exec.exec(pipPath, ["install", "--upgrade", `aws-sam-cli==${version}`]);
+  await exec.exec(pythonPath, [
+    "-m",
+    "pip",
+    "install",
+    "--upgrade",
+    `aws-sam-cli==${version}`,
+  ]);
 
   return binPath;
 }


### PR DESCRIPTION
### Which issue does this fix?

https://github.com/aws-actions/setup-sam/issues/5

### Description of changes

Upgrades `pip`, `setuptools` and `wheel` before installation. They're core to the installation process and can vary wildly between platforms. This ensures they're consistent across platforms.

Using `-m pip` is [needed by Windows](https://github.community/t/new-permissions-errors-while-running-pip-install-upgrade-pip-on-windows/18323).