### PR TITLE
feat: isolate symlink

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -99,7 +99,12 @@ async function installSamCli(python, version) {
     `aws-sam-cli==${version}`,
   ]);
 
-  return binPath;
+  // Symlink from separate directory so only SAM CLI is added to PATH
+  const symlinkPath = mkdirTemp();
+  const sam = isWindows() ? "sam.exe" : "sam";
+  fs.symlinkSync(path.join(binPath, sam), path.join(symlinkPath, sam));
+
+  return symlinkPath;
 }
 
 /**

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -74,7 +74,12 @@ async function installSamCli(python, version) {
     `aws-sam-cli==${version}`,
   ]);
 
-  return binPath;
+  // Symlink from separate directory so only SAM CLI is added to PATH
+  const symlinkPath = mkdirTemp();
+  const sam = isWindows() ? "sam.exe" : "sam";
+  fs.symlinkSync(path.join(binPath, sam), path.join(symlinkPath, sam));
+
+  return symlinkPath;
 }
 
 /**


### PR DESCRIPTION
Resolves https://github.com/aws-actions/setup-sam/issues/6

Puts `sam` symlink in its separate directory so that _only_ `sam` is added to the `PATH`.