### PR TITLE
feat: keep all files under a single directory

### DIFF
--- a/lib/setup.js
+++ b/lib/setup.js
@@ -24,16 +24,13 @@ function mkdirTemp() {
  * Creates a Python virtual environment.
  *
  * @param {string} python - The Python interpreter to use.
- * @returns {Promise<string>} The path to the virtual environment.
+ * @param {string} venvPath - The virtual environment directory.
  */
-async function createPythonVenv(python) {
-  const venvPath = mkdirTemp();
+async function createPythonVenv(python, venvPath) {
   const pythonPath = await io.which(python, true);
 
   await exec.exec(pythonPath, ["--version"]);
   await exec.exec(pythonPath, ["-m", "venv", venvPath]);
-
-  return venvPath;
 }
 
 /**
@@ -44,7 +41,11 @@ async function createPythonVenv(python) {
  * @returns {Promise<string>} The directory SAM CLI is installed in.
  */
 async function installSamCli(python, version) {
-  const venvPath = await createPythonVenv(python);
+  const tempPath = mkdirTemp();
+
+  // Create virtual environment
+  const venvPath = path.join(tempPath, ".venv");
+  await createPythonVenv(python, venvPath);
 
   // See https://docs.python.org/3/library/venv.html
   const binDir = isWindows() ? "Scripts" : "bin";
@@ -75,7 +76,8 @@ async function installSamCli(python, version) {
   ]);
 
   // Symlink from separate directory so only SAM CLI is added to PATH
-  const symlinkPath = mkdirTemp();
+  const symlinkPath = path.join(tempPath, "bin");
+  fs.mkdirSync(symlinkPath);
   const sam = isWindows() ? "sam.exe" : "sam";
   fs.symlinkSync(path.join(binPath, sam), path.join(symlinkPath, sam));
 


### PR DESCRIPTION
#### Which issue(s) does this change fix?

#16

#### Description

Creates all files under a single directory.

Will make it simpler to potentially use [`@actions/tool-cache`](https://github.com/actions/toolkit/tree/main/packages/tool-cache) and/or store files under [`RUNNER_TEMP`](https://github.com/actions/toolkit/issues/518).

#### Checklist

- [x] Run `npm run all`
- [x] Update tests (if necessary)
- [x] Commit messages and PR title follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache-2.0 License](https://www.apache.org/licenses/LICENSE-2.0).
