### PR TITLE
chore: prefer RUNNER_TEMP

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -42,6 +42,8 @@ function isWindows() {
  * Returns a new temporary directory.
  */
 function mkdirTemp() {
+  console.log("hey", process.env.RUNNER_TEMP);
+  console.log("wut", os.tmpdir());
   return fs.mkdtempSync(path.join(os.tmpdir(), "setup-sam-"));
 }
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -42,9 +42,8 @@ function isWindows() {
  * Returns a new temporary directory.
  */
 function mkdirTemp() {
-  console.log("hey", process.env.RUNNER_TEMP);
-  console.log("wut", os.tmpdir());
-  return fs.mkdtempSync(path.join(os.tmpdir(), "setup-sam-"));
+  const tempDir = process.env.RUNNER_TEMP || os.tmpdir();
+  return fs.mkdtempSync(path.join(tempDir, "setup-sam-"));
 }
 
 /**

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -17,9 +17,8 @@ function isWindows() {
  * Returns a new temporary directory.
  */
 function mkdirTemp() {
-  console.log("hey", process.env.RUNNER_TEMP);
-  console.log("wut", os.tmpdir());
-  return fs.mkdtempSync(path.join(os.tmpdir(), "setup-sam-"));
+  const tempDir = process.env.RUNNER_TEMP || os.tmpdir();
+  return fs.mkdtempSync(path.join(tempDir, "setup-sam-"));
 }
 
 /**

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -17,6 +17,8 @@ function isWindows() {
  * Returns a new temporary directory.
  */
 function mkdirTemp() {
+  console.log("hey", process.env.RUNNER_TEMP);
+  console.log("wut", os.tmpdir());
   return fs.mkdtempSync(path.join(os.tmpdir(), "setup-sam-"));
 }
 


### PR DESCRIPTION
#### Which issue(s) does this change fix?

N/A

#### Description

Uses `RUNNER_TEMP` as preferred temporary directory, which is cleaned up after each job (see https://github.com/actions/toolkit/issues/518).

- [actions/toolkit](https://github.com/actions/toolkit/blob/ddd04b6997d9d8ccdb1f4434d9b1205066d5e091/packages/cache/src/internal/cacheUtils.ts#L16)
- [actions/setup-node](https://github.com/actions/setup-node/blob/5c355be17065acf11598c7a9bb47112fbcf2bbdc/src/installer.ts#L346)

[`runner.temp`](https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#runner-context) mentioned in the docs.

#### Checklist

- [x] Run `npm run all`
- [x] Update tests (if necessary)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) style

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache-2.0 License](https://www.apache.org/licenses/LICENSE-2.0).
