### PR TITLE
Specify python version in setup-python step

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: "3.8"
       - uses: aws-actions/setup-sam@v1
       - uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.8'
+          python-version: 3.8
       - uses: aws-actions/setup-sam@v1
       - uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
+        with:
+          python-version: '3.8'
       - uses: aws-actions/setup-sam@v1
       - uses: aws-actions/configure-aws-credentials@v1
         with:


### PR DESCRIPTION
AWS SAM CLI doesn't officially support 3.9, which is by default installed by setup-python v2

#### Which issue(s) does this change fix?

#### Description

#### Checklist

- [ ] Run `npm run all`
- [ ] Update tests (if necessary)
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) style

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache-2.0 License](https://www.apache.org/licenses/LICENSE-2.0).
