### PR TITLE
chore: do not test on windows-2016

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,6 @@ jobs:
         os:
           - ubuntu-18.04
           - ubuntu-20.04
-          - windows-2016
           - windows-2019
           - windows-2022
           - macos-10.15


### PR DESCRIPTION
#### Which issue(s) does this change fix?

https://github.blog/changelog/2021-10-19-github-actions-the-windows-2016-runner-image-will-be-removed-from-github-hosted-runners-on-march-15-2022/

#### Description

#### Checklist

- [ ] Run `npm run all`
- [ ] Update tests (if necessary)
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) style

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache-2.0 License](https://www.apache.org/licenses/LICENSE-2.0).
