### PR TITLE
chore: use setup-python@v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.8"
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.8"
       - uses: aws-actions/setup-sam@v2


### PR DESCRIPTION
#### Which issue(s) does this change fix?

#### Description

`v3` is giving warnings, see e.g. before (https://github.com/aws-actions/setup-sam/actions/runs/3867925638) and after (https://github.com/aws-actions/setup-sam/actions/runs/3905263751)

#### Checklist

- [x] Run `npm run all`
- [x] Update tests (if necessary)

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache-2.0 License](https://www.apache.org/licenses/LICENSE-2.0).
