### PR TITLE
ci: test `use-installer` in separate job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,34 @@ jobs:
       - run: npm ci
       - run: npm test
 
+  native-installer:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - ubuntu-22.04
+    name: Native installer / ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Test official installer (pinned version)
+        uses: ./
+        with:
+          use-installer: true
+          version: "1.71.0"
+      - run: sam --version | grep -F 1.71.0
+
+      - name: Test official installer (latest version)
+        uses: ./
+        with:
+          use-installer: true
+      - run: |
+          version=$(curl https://pypi.org/pypi/aws-sam-cli/json | jq -r .info.version)
+          sam --version | grep -F "$version"
+        shell: bash 
+
   integ:
     strategy:
       fail-fast: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,6 +60,26 @@ jobs:
         with:
           python-version: "3.8"
 
+      - name: Test official installer (pinned version)
+        if: startsWith(matrix.os, 'ubuntu')
+        uses: ./
+        with:
+          use-installer: true
+          version: "1.71.0"
+      - if: startsWith(matrix.os, 'ubuntu')
+        run: sam --version | grep -F 1.71.0
+
+      - name: Test official installer (latest version)
+        if: startsWith(matrix.os, 'ubuntu')
+        uses: ./
+        with:
+          use-installer: true
+      - if: startsWith(matrix.os, 'ubuntu')
+        run: |
+          version=$(curl https://pypi.org/pypi/aws-sam-cli/json | jq -r .info.version)
+          sam --version | grep -F "$version"
+        shell: bash
+
       # Test latest published version
       - uses: aws-actions/setup-sam@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,26 +60,6 @@ jobs:
         with:
           python-version: "3.8"
 
-      - name: Test official installer (pinned version)
-        if: startsWith(matrix.os, 'ubuntu')
-        uses: ./
-        with:
-          use-installer: true
-          version: "1.71.0"
-      - if: startsWith(matrix.os, 'ubuntu')
-        run: sam --version | grep -F 1.71.0
-
-      - name: Test official installer (latest version)
-        if: startsWith(matrix.os, 'ubuntu')
-        uses: ./
-        with:
-          use-installer: true
-      - if: startsWith(matrix.os, 'ubuntu')
-        run: |
-          version=$(curl https://pypi.org/pypi/aws-sam-cli/json | jq -r .info.version)
-          sam --version | grep -F "$version"
-        shell: bash
-
       # Test latest published version
       - uses: aws-actions/setup-sam@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
       - run: |
           version=$(curl https://pypi.org/pypi/aws-sam-cli/json | jq -r .info.version)
           sam --version | grep -F "$version"
-        shell: bash 
+        shell: bash
 
   integ:
     strategy:

--- a/dist/index.js
+++ b/dist/index.js
@@ -143,7 +143,7 @@ function getInput(name, pattern, defaultValue) {
 // TODO: Support caching
 async function installUsingNativeInstaller(version) {
   if (os.platform() !== "linux" || os.arch() !== "x64") {
-    core.setFailed("Only Linux x86-64 is supported with installer: true");
+    core.setFailed("Only Linux x86-64 is supported with use-installer: true");
     return "";
   }
 


### PR DESCRIPTION
#### Which issue(s) does this change fix?

#### Description

Testing in separate job without `setup-python` done beforehand.

#### Checklist

- [x] Change is backward compatible (if not, add [a new input](https://github.com/aws-actions/setup-sam#inputs) or [update major version](https://github.com/aws-actions/setup-sam/blob/main/.github/workflows/release.yml))
- [x] Run `npm run all`
- [x] Update tests (if necessary)

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache-2.0 License](https://www.apache.org/licenses/LICENSE-2.0).
