### PR TITLE
perf: cache when `use-installer` and `version` specified

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,13 @@ jobs:
           version: "1.71.0"
       - run: sam --version | grep -F 1.71.0
 
+      - name: Test official installer (pinned version; should use cache)
+        uses: ./
+        with:
+          use-installer: true
+          version: "1.71.0"
+      - run: sam --version | grep -F 1.71.0
+
       - name: Test official installer (latest version)
         uses: ./
         with:

--- a/dist/index.js
+++ b/dist/index.js
@@ -147,13 +147,20 @@ async function installUsingNativeInstaller(version) {
     return "";
   }
 
+  const cachedPath = tc.find("sam", version);
+  if (cachedPath) {
+    core.info(`Using cached AWS SAM CLI from ${cachedPath}`);
+    return path.join(cachedPath, "dist");
+  }
+
   const url = version
     ? `https://github.com/aws/aws-sam-cli/releases/download/v${version}/aws-sam-cli-linux-x86_64.zip`
     : "https://github.com/aws/aws-sam-cli/releases/latest/download/aws-sam-cli-linux-x86_64.zip";
 
   const toolPath = await tc.downloadTool(url);
   const extractedDir = await tc.extractZip(toolPath);
-  const binDir = path.join(extractedDir, "dist");
+  const cachedDir = await tc.cacheDir(extractedDir, "sam", version);
+  const binDir = path.join(cachedDir, "dist");
 
   return binDir;
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -132,6 +132,13 @@ function getInput(name, pattern, defaultValue) {
 }
 
 /**
+ * Returns whether a string is in the format x.y.z.
+ */
+function isSemver(s) {
+  return /^\d.\d.\d$/.test(s);
+}
+
+/**
  * Installs SAM CLI using the native installers.
  *
  * See https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/install-sam-cli.html
@@ -143,6 +150,12 @@ function getInput(name, pattern, defaultValue) {
 async function installUsingNativeInstaller(version) {
   if (os.platform() !== "linux" || os.arch() !== "x64") {
     core.setFailed("Only Linux x86-64 is supported with use-installer: true");
+    return "";
+  }
+
+  // Must be full semantic version; downloads version directly from GitHub
+  if (version && !isSemver(version)) {
+    core.setFailed("Version must be in the format x.y.z");
     return "";
   }
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -140,7 +140,6 @@ function getInput(name, pattern, defaultValue) {
  * @returns {Promise<string>} The directory SAM CLI is installed in.
  */
 // TODO: Support more platforms
-// TODO: Support caching
 async function installUsingNativeInstaller(version) {
   if (os.platform() !== "linux" || os.arch() !== "x64") {
     core.setFailed("Only Linux x86-64 is supported with use-installer: true");

--- a/dist/index.js
+++ b/dist/index.js
@@ -167,6 +167,7 @@ async function installUsingNativeInstaller(version) {
   if (version) {
     const cachedDir = await tc.cacheDir(extractedDir, "sam", version);
     core.info(`Cached AWS SAM CLI ${version} to ${cachedDir}`);
+    return path.join(cachedDir, "dist");
   }
 
   return binDir;

--- a/dist/index.js
+++ b/dist/index.js
@@ -146,6 +146,7 @@ async function installUsingNativeInstaller(version) {
     return "";
   }
 
+  // TODO: If not set, check latest version and return from cache if exists
   if (version) {
     const cachedDir = tc.find("sam", version);
     if (cachedDir) {
@@ -162,6 +163,7 @@ async function installUsingNativeInstaller(version) {
   const extractedDir = await tc.extractZip(toolPath);
   const binDir = path.join(extractedDir, "dist");
 
+  // TODO: If not set, cache with latest version
   if (version) {
     const cachedDir = await tc.cacheDir(extractedDir, "sam", version);
     core.info(`Cached AWS SAM CLI ${version} to ${cachedDir}`);

--- a/dist/index.js
+++ b/dist/index.js
@@ -149,7 +149,7 @@ async function installUsingNativeInstaller(version) {
   if (version) {
     const cachedDir = tc.find("sam", version);
     if (cachedDir) {
-      core.info(`Using cached AWS SAM CLI from ${cachedDir}`);
+      core.info(`Using cached AWS SAM CLI ${version} from ${cachedDir}`);
       return path.join(cachedDir, "dist");
     }
   }
@@ -160,8 +160,12 @@ async function installUsingNativeInstaller(version) {
 
   const toolPath = await tc.downloadTool(url);
   const extractedDir = await tc.extractZip(toolPath);
-  const cachedDir = await tc.cacheDir(extractedDir, "sam", version);
-  const binDir = path.join(cachedDir, "dist");
+  const binDir = path.join(extractedDir, "dist");
+
+  if (version) {
+    const cachedDir = await tc.cacheDir(extractedDir, "sam", version);
+    core.info(`Cached AWS SAM CLI ${version} to ${cachedDir}`);
+  }
 
   return binDir;
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -135,7 +135,7 @@ function getInput(name, pattern, defaultValue) {
  * Returns whether a string is in the format x.y.z.
  */
 function isSemver(s) {
-  return /^\d.\d.\d$/.test(s);
+  return /^\d+\.\d+\.\d+$/.test(s);
 }
 
 /**

--- a/dist/index.js
+++ b/dist/index.js
@@ -147,10 +147,12 @@ async function installUsingNativeInstaller(version) {
     return "";
   }
 
-  const cachedPath = tc.find("sam", version);
-  if (cachedPath) {
-    core.info(`Using cached AWS SAM CLI from ${cachedPath}`);
-    return path.join(cachedPath, "dist");
+  if (version) {
+    const cachedPath = tc.find("sam", version);
+    if (cachedPath) {
+      core.info(`Using cached AWS SAM CLI from ${cachedPath}`);
+      return path.join(cachedPath, "dist");
+    }
   }
 
   const url = version

--- a/dist/index.js
+++ b/dist/index.js
@@ -147,10 +147,10 @@ async function installUsingNativeInstaller(version) {
   }
 
   if (version) {
-    const cachedPath = tc.find("sam", version);
-    if (cachedPath) {
-      core.info(`Using cached AWS SAM CLI from ${cachedPath}`);
-      return path.join(cachedPath, "dist");
+    const cachedDir = tc.find("sam", version);
+    if (cachedDir) {
+      core.info(`Using cached AWS SAM CLI from ${cachedDir}`);
+      return path.join(cachedDir, "dist");
     }
   }
 

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -135,8 +135,12 @@ async function installUsingNativeInstaller(version) {
 
   const toolPath = await tc.downloadTool(url);
   const extractedDir = await tc.extractZip(toolPath);
-  const cachedDir = await tc.cacheDir(extractedDir, "sam", version);
-  const binDir = path.join(cachedDir, "dist");
+  const binDir = path.join(extractedDir, "dist");
+
+  if (version) {
+    const cachedDir = await tc.cacheDir(extractedDir, "sam", version);
+    core.info(`Cached AWS SAM CLI ${version} to ${cachedDir}`);
+  }
 
   return binDir;
 }

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -124,7 +124,7 @@ async function installUsingNativeInstaller(version) {
   if (version) {
     const cachedDir = tc.find("sam", version);
     if (cachedDir) {
-      core.info(`Using cached AWS SAM CLI from ${cachedDir}`);
+      core.info(`Using cached AWS SAM CLI ${version} from ${cachedDir}`);
       return path.join(cachedDir, "dist");
     }
   }

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -122,10 +122,10 @@ async function installUsingNativeInstaller(version) {
   }
 
   if (version) {
-    const cachedPath = tc.find("sam", version);
-    if (cachedPath) {
-      core.info(`Using cached AWS SAM CLI from ${cachedPath}`);
-      return path.join(cachedPath, "dist");
+    const cachedDir = tc.find("sam", version);
+    if (cachedDir) {
+      core.info(`Using cached AWS SAM CLI from ${cachedDir}`);
+      return path.join(cachedDir, "dist");
     }
   }
 

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -115,7 +115,6 @@ function getInput(name, pattern, defaultValue) {
  * @returns {Promise<string>} The directory SAM CLI is installed in.
  */
 // TODO: Support more platforms
-// TODO: Support caching
 async function installUsingNativeInstaller(version) {
   if (os.platform() !== "linux" || os.arch() !== "x64") {
     core.setFailed("Only Linux x86-64 is supported with use-installer: true");

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -142,6 +142,7 @@ async function installUsingNativeInstaller(version) {
   if (version) {
     const cachedDir = await tc.cacheDir(extractedDir, "sam", version);
     core.info(`Cached AWS SAM CLI ${version} to ${cachedDir}`);
+    return path.join(cachedDir, "dist");
   }
 
   return binDir;

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -125,7 +125,7 @@ async function installUsingNativeInstaller(version) {
   const cachedPath = tc.find("sam", version);
   if (cachedPath) {
     core.info(`Using cached AWS SAM CLI from ${cachedPath}`);
-    return path.join(cachedPath, "dist")
+    return path.join(cachedPath, "dist");
   }
 
   const url = version

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -122,13 +122,20 @@ async function installUsingNativeInstaller(version) {
     return "";
   }
 
+  const cachedPath = tc.find("sam", version);
+  if (cachedPath) {
+    core.info(`Using cached AWS SAM CLI from ${cachedPath}`);
+    return path.join(cachedPath, "dist")
+  }
+
   const url = version
     ? `https://github.com/aws/aws-sam-cli/releases/download/v${version}/aws-sam-cli-linux-x86_64.zip`
     : "https://github.com/aws/aws-sam-cli/releases/latest/download/aws-sam-cli-linux-x86_64.zip";
 
   const toolPath = await tc.downloadTool(url);
   const extractedDir = await tc.extractZip(toolPath);
-  const binDir = path.join(extractedDir, "dist");
+  const cachedDir = await tc.cacheDir(extractedDir, "sam", version);
+  const binDir = path.join(cachedDir, "dist");
 
   return binDir;
 }

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -107,6 +107,13 @@ function getInput(name, pattern, defaultValue) {
 }
 
 /**
+ * Returns whether a string is in the format x.y.z.
+ */
+function isSemver(s) {
+  return /^\d.\d.\d$/.test(s);
+}
+
+/**
  * Installs SAM CLI using the native installers.
  *
  * See https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/install-sam-cli.html
@@ -118,6 +125,12 @@ function getInput(name, pattern, defaultValue) {
 async function installUsingNativeInstaller(version) {
   if (os.platform() !== "linux" || os.arch() !== "x64") {
     core.setFailed("Only Linux x86-64 is supported with use-installer: true");
+    return "";
+  }
+
+  // Must be full semantic version; downloads version directly from GitHub
+  if (version && !isSemver(version)) {
+    core.setFailed("Version must be in the format x.y.z");
     return "";
   }
 

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -121,6 +121,7 @@ async function installUsingNativeInstaller(version) {
     return "";
   }
 
+  // TODO: If not set, check latest version and return from cache if exists
   if (version) {
     const cachedDir = tc.find("sam", version);
     if (cachedDir) {
@@ -137,6 +138,7 @@ async function installUsingNativeInstaller(version) {
   const extractedDir = await tc.extractZip(toolPath);
   const binDir = path.join(extractedDir, "dist");
 
+  // TODO: If not set, cache with latest version
   if (version) {
     const cachedDir = await tc.cacheDir(extractedDir, "sam", version);
     core.info(`Cached AWS SAM CLI ${version} to ${cachedDir}`);

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -110,7 +110,7 @@ function getInput(name, pattern, defaultValue) {
  * Returns whether a string is in the format x.y.z.
  */
 function isSemver(s) {
-  return /^\d.\d.\d$/.test(s);
+  return /^\d+\.\d+\.\d+$/.test(s);
 }
 
 /**

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -122,10 +122,12 @@ async function installUsingNativeInstaller(version) {
     return "";
   }
 
-  const cachedPath = tc.find("sam", version);
-  if (cachedPath) {
-    core.info(`Using cached AWS SAM CLI from ${cachedPath}`);
-    return path.join(cachedPath, "dist");
+  if (version) {
+    const cachedPath = tc.find("sam", version);
+    if (cachedPath) {
+      core.info(`Using cached AWS SAM CLI from ${cachedPath}`);
+      return path.join(cachedPath, "dist");
+    }
   }
 
   const url = version

--- a/test/setup.test.js
+++ b/test/setup.test.js
@@ -98,6 +98,9 @@ test("when use-installer enabled and version specified and cached version exists
 
   expect(tc.find).toHaveBeenCalledTimes(1);
   expect(tc.cacheDir).toHaveBeenCalledTimes(0);
+
+  // Must be cached path
+  expect(core.addPath).toHaveBeenCalledWith("/path/to/cached/sam/dist");
 });
 
 test("when use-installer enabled and version specified and cached version does not exist, downloads and caches version", async () => {
@@ -108,11 +111,39 @@ test("when use-installer enabled and version specified and cached version does n
   core.getInput = jest.fn().mockReturnValueOnce("1.2.3");
 
   tc.find = jest.fn().mockReturnValueOnce("");
-  tc.extractZip = jest.fn().mockReturnValueOnce("/path/to/cached/sam");
+  tc.extractZip = jest.fn().mockReturnValueOnce("/path/to/extracted/sam");
   tc.cacheDir = jest.fn().mockReturnValueOnce("/path/to/cached/sam");
 
   await setup();
 
   expect(tc.find).toHaveBeenCalledTimes(1);
   expect(tc.cacheDir).toHaveBeenCalledTimes(1);
+
+  // Must return cached path
+  expect(core.addPath).toHaveBeenCalledWith("/path/to/cached/sam/dist");
+});
+
+test("when use-installer enabled and version not specified, downloads latest version (Linux x64)", async () => {
+  jest.spyOn(os, "platform").mockReturnValue("linux");
+  jest.spyOn(os, "arch").mockReturnValue("x64");
+
+  core.getBooleanInput = jest.fn().mockReturnValue(true);
+  core.getInput = jest.fn().mockReturnValueOnce("");
+
+  tc.find = jest.fn().mockReturnValueOnce("");
+  tc.extractZip = jest.fn().mockReturnValueOnce("/path/to/extracted/sam");
+  tc.cacheDir = jest.fn().mockReturnValueOnce("/path/to/cached/sam");
+  tc.downloadTool = jest.fn().mockReturnValueOnce("/path/to/downloaded/sam");
+
+  await setup();
+
+  // Currently no caching on latest
+  expect(tc.find).toHaveBeenCalledTimes(0);
+  expect(tc.cacheDir).toHaveBeenCalledTimes(0);
+
+  expect(tc.downloadTool).toHaveBeenCalledWith(
+    "https://github.com/aws/aws-sam-cli/releases/latest/download/aws-sam-cli-linux-x86_64.zip"
+  );
+
+  expect(core.addPath).toHaveBeenCalledWith("/path/to/extracted/sam/dist");
 });

--- a/test/setup.test.js
+++ b/test/setup.test.js
@@ -90,7 +90,7 @@ test("when use-installer enabled and version specified and cached version exists
   jest.spyOn(os, "arch").mockReturnValue("x64");
 
   core.getBooleanInput = jest.fn().mockReturnValue(true);
-  core.getInput = jest.fn().mockReturnValueOnce("1.2.3");
+  core.getInput = jest.fn().mockReturnValueOnce("1.23.456");
 
   tc.find = jest.fn().mockReturnValueOnce("/path/to/cached/sam");
 
@@ -108,7 +108,7 @@ test("when use-installer enabled and version specified and cached version does n
   jest.spyOn(os, "arch").mockReturnValue("x64");
 
   core.getBooleanInput = jest.fn().mockReturnValue(true);
-  core.getInput = jest.fn().mockReturnValueOnce("1.2.3");
+  core.getInput = jest.fn().mockReturnValueOnce("1.23.456");
 
   tc.find = jest.fn().mockReturnValueOnce("");
   tc.extractZip = jest.fn().mockReturnValueOnce("/path/to/extracted/sam");

--- a/test/setup.test.js
+++ b/test/setup.test.js
@@ -137,13 +137,12 @@ test("when use-installer enabled and version not specified, downloads latest ver
 
   await setup();
 
-  // Currently no caching on latest
-  expect(tc.find).toHaveBeenCalledTimes(0);
-  expect(tc.cacheDir).toHaveBeenCalledTimes(0);
-
   expect(tc.downloadTool).toHaveBeenCalledWith(
     "https://github.com/aws/aws-sam-cli/releases/latest/download/aws-sam-cli-linux-x86_64.zip"
   );
 
+  // Currently no caching on latest
+  expect(tc.find).toHaveBeenCalledTimes(0);
+  expect(tc.cacheDir).toHaveBeenCalledTimes(0);
   expect(core.addPath).toHaveBeenCalledWith("/path/to/extracted/sam/dist");
 });

--- a/test/setup.test.js
+++ b/test/setup.test.js
@@ -147,7 +147,7 @@ test("when use-installer enabled and version not specified, downloads latest ver
   expect(core.addPath).toHaveBeenCalledWith("/path/to/extracted/sam/dist");
 });
 
-test("when use-installer enabled but version is either '1.2', '1.2.a', or 'foo', downloadTool is not called", async () => {
+test("when use-installer enabled but version is not in format x.y.z, not downloaded or checked in cache", async () => {
   jest.spyOn(os, "platform").mockReturnValue("linux");
   jest.spyOn(os, "arch").mockReturnValue("x64");
 
@@ -157,5 +157,6 @@ test("when use-installer enabled but version is either '1.2', '1.2.a', or 'foo',
     core.getInput = jest.fn().mockReturnValueOnce(version);
     await setup();
     expect(tc.downloadTool).toHaveBeenCalledTimes(0);
+    expect(tc.find).toHaveBeenCalledTimes(0);
   }
 });

--- a/test/setup.test.js
+++ b/test/setup.test.js
@@ -146,3 +146,16 @@ test("when use-installer enabled and version not specified, downloads latest ver
   expect(tc.cacheDir).toHaveBeenCalledTimes(0);
   expect(core.addPath).toHaveBeenCalledWith("/path/to/extracted/sam/dist");
 });
+
+test("when use-installer enabled but version is either '1.2', '1.2.a', or 'foo', downloadTool is not called", async () => {
+  jest.spyOn(os, "platform").mockReturnValue("linux");
+  jest.spyOn(os, "arch").mockReturnValue("x64");
+
+  core.getBooleanInput = jest.fn().mockReturnValue(true);
+
+  for (const version of ["1.2", "1.*", "3"]) {
+    core.getInput = jest.fn().mockReturnValueOnce(version);
+    await setup();
+    expect(tc.downloadTool).toHaveBeenCalledTimes(0);
+  }
+});


### PR DESCRIPTION
#### Which issue(s) does this change fix?

#12 

#### Description

Caches SAM CLI when `use-installer` and `version` are specified.

#### Checklist

- [x] Change is backward compatible (if not, add [a new input](https://github.com/aws-actions/setup-sam#inputs) or [update major version](https://github.com/aws-actions/setup-sam/blob/main/.github/workflows/release.yml))
- [x] Run `npm run all`
- [x] Update tests (if necessary)

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache-2.0 License](https://www.apache.org/licenses/LICENSE-2.0).
