### PR TITLE
fix: Update message when failed to fetch latest version

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -176,7 +176,9 @@ async function installUsingNativeInstaller(inputVersion) {
     const latestVersion = await getLatestReleaseTag("aws/aws-sam-cli");
     // Must be full semantic version; downloads version directly from GitHub
     if (latestVersion && !isSemver(latestVersion)) {
-      core.setFailed("Latest version found must be in the format x.y.z");
+      core.info(
+        "Fetched version is not in the format x.y.z. Use latest version without caching."
+      );
       return "";
     }
     version = latestVersion;

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -170,7 +170,9 @@ async function installUsingNativeInstaller(inputVersion) {
     const latestVersion = await getLatestReleaseTag("aws/aws-sam-cli");
     // Must be full semantic version; downloads version directly from GitHub
     if (latestVersion && !isSemver(latestVersion)) {
-      core.info("Fetched version is not in the format x.y.z. Use latest version without caching.");
+      core.info(
+        "Fetched version is not in the format x.y.z. Use latest version without caching."
+      );
       return "";
     }
     version = latestVersion;

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -170,7 +170,7 @@ async function installUsingNativeInstaller(inputVersion) {
     const latestVersion = await getLatestReleaseTag("aws/aws-sam-cli");
     // Must be full semantic version; downloads version directly from GitHub
     if (latestVersion && !isSemver(latestVersion)) {
-      core.setFailed("Latest version found must be in the format x.y.z");
+      core.info("Fetched version is not in the format x.y.z. Use latest version without caching.");
       return "";
     }
     version = latestVersion;


### PR DESCRIPTION
#### Which issue(s) does this change fix?

#### Description
A minor change that doesn't fail the gh action when the fetched version is incorrect format.

#### Checklist

- [ ] Change is backward compatible (if not, add [a new input](https://github.com/aws-actions/setup-sam#inputs) or [update major version](https://github.com/aws-actions/setup-sam/blob/main/.github/workflows/release.yml))
- [ ] Run `npm run all`
- [ ] Update tests (if necessary)

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache-2.0 License](https://www.apache.org/licenses/LICENSE-2.0).
