### PR TITLE
Allow setup sam to continue when failed to get release tag

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -145,7 +145,7 @@ async function getLatestReleaseTag() {
     const data = JSON.parse(await response.readBody());
     return data.tag_name.substring(1);
   } catch (error) {
-    core.setFailed("Error:", error);
+    core.info("Unable to get SAM CLI's latest release tag ", error);
     return "";
   }
 }

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -139,7 +139,7 @@ async function getLatestReleaseTag() {
     const data = JSON.parse(await response.readBody());
     return data.tag_name.substring(1);
   } catch (error) {
-    core.setFailed("Error:", error);
+    core.info("Unable to get SAM CLI's latest release tag ", error);
     return "";
   }
 }


### PR DESCRIPTION
#### Which issue(s) does this change fix?
https://github.com/aws-actions/setup-sam/issues/91

#### Description
There's a bug from the previous PR to enable caching when version is not specified. When failed to get the latest tag from SAM CLI, we set it to failed state which stopped the execution. 

However, we should have allowed it to continue and only logged the message.

#### Checklist

- [x] Change is backward compatible (if not, add [a new input](https://github.com/aws-actions/setup-sam#inputs) or [update major version](https://github.com/aws-actions/setup-sam/blob/main/.github/workflows/release.yml))
- [x] Run `npm run all`
- [x] Update tests (if necessary)

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache-2.0 License](https://www.apache.org/licenses/LICENSE-2.0).
