### PR TITLE
Make hash character range less permissive

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -22416,7 +22416,7 @@ function bytesMatch (bytes, metadataList) {
 // https://w3c.github.io/webappsec-subresource-integrity/#grammardef-hash-with-options
 // https://www.w3.org/TR/CSP2/#source-list-syntax
 // https://www.rfc-editor.org/rfc/rfc5234#appendix-B.1
-const parseHashWithOptions = /((?<algo>sha256|sha384|sha512)-(?<hash>[A-z0-9+/]{1}.*={0,2}))( +[\x21-\x7e]?)?/i
+const parseHashWithOptions = /((?<algo>sha256|sha384|sha512)-(?<hash>[A-Za-z0-9+/]{1}.*={0,2}))( +[\x21-\x7e]?)?/i
 
 /**
  * @see https://w3c.github.io/webappsec-subresource-integrity/#parse-metadata


### PR DESCRIPTION
#### Which issue(s) does this change fix?
Overly permissive regex `A-z0-9+` changed to `A-Za-z0-9+` This should include hashes in hex or 64 bit.

#### Description

#### Checklist

- [ ] Change is backward compatible (if not, add [a new input](https://github.com/aws-actions/setup-sam#inputs) or [update major version](https://github.com/aws-actions/setup-sam/blob/main/.github/workflows/release.yml))
- [x] Run `npm run all`
- [ ] Update tests (if necessary)

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache-2.0 License](https://www.apache.org/licenses/LICENSE-2.0).
